### PR TITLE
Add Flask web interface for legal rinse agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
 # ZeroQuant v2.0
 
 Deployment-ready cockpit system.
+
+## Legal Rinse Agent
+
+This repository includes a small tool for verifying legal citations. You can run it from the command line or via a minimal web interface.
+
+### Command Line
+
+```bash
+python -m legal_rinse.main <file-or-text>
+```
+
+### Web Interface
+
+Install dependencies and start the Flask app:
+
+```bash
+pip install flask requests
+python -m legal_rinse.app
+```
+
+Then open `http://localhost:5000` in your browser (iPhone, iPad, or desktop) and submit text or a document for verification.
+

--- a/legal_rinse/app.py
+++ b/legal_rinse/app.py
@@ -1,0 +1,38 @@
+from flask import Flask, request, render_template_string
+from parser import read_text
+from extractor import extract_citations
+from verifier import verify_citation
+from report import generate_report
+from utils import log
+
+app = Flask(__name__)
+
+FORM_HTML = """
+<!doctype html>
+<title>Legal Rinse Agent</title>
+<h1>Verify Legal Citations</h1>
+<form method=post enctype=multipart/form-data>
+  <textarea name=text cols=80 rows=10 placeholder="Paste legal text here"></textarea><br>
+  <input type=file name=file><br>
+  <input type=submit value=Verify>
+</form>
+<pre>{{ result }}</pre>
+"""
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    result = ""
+    if request.method == 'POST':
+        text = request.form.get('text') or ''
+        if 'file' in request.files and request.files['file']:
+            file = request.files['file']
+            text += file.read().decode('utf-8')
+        if text:
+            log("Processing input text")
+            citations = extract_citations(text)
+            res = [verify_citation(c) for c in citations]
+            result = generate_report(res)
+    return render_template_string(FORM_HTML, result=result)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/legal_rinse/extractor.py
+++ b/legal_rinse/extractor.py
@@ -1,0 +1,11 @@
+import re
+from typing import List
+
+CITATION_REGEX = re.compile(
+    r"\b([A-Z][a-zA-Z]+ v\. [A-Z][a-zA-Z]+, \d+ [A-Z\.]+ \d+ \(\d{4}\))\b"
+)
+
+
+def extract_citations(text: str) -> List[str]:
+    """Return a list of legal citation strings."""
+    return CITATION_REGEX.findall(text)

--- a/legal_rinse/main.py
+++ b/legal_rinse/main.py
@@ -1,0 +1,28 @@
+from parser import read_text
+from extractor import extract_citations
+from verifier import verify_citation
+from quote_checker import verify_quote
+from report import generate_report
+from utils import log
+
+
+def run_verification(input_source: str) -> None:
+    text = read_text(input_source)
+    citations = extract_citations(text)
+    log(f"Found {len(citations)} citation(s)")
+    results = []
+    for c in citations:
+        result = verify_citation(c)
+        # Quote verification placeholder
+        results.append(result)
+    summary = generate_report(results)
+    print(summary)
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) != 2:
+        print("Usage: python -m legal_rinse.main <file-or-text>")
+        raise SystemExit(1)
+    run_verification(sys.argv[1])

--- a/legal_rinse/parser.py
+++ b/legal_rinse/parser.py
@@ -1,0 +1,10 @@
+import pathlib
+from typing import Union
+
+
+def read_text(path_or_string: str) -> str:
+    """Read from a file path or return the string as-is."""
+    p = pathlib.Path(path_or_string)
+    if p.exists():
+        return p.read_text()
+    return path_or_string

--- a/legal_rinse/quote_checker.py
+++ b/legal_rinse/quote_checker.py
@@ -1,0 +1,6 @@
+def verify_quote(citation: str, quoted_text: str) -> dict:
+    """Placeholder for quote verification logic."""
+    # Real implementation would compare `quoted_text` with the official
+    # source text from the citation. This requires access to the full
+    # opinion text from the database, which may not be publicly available.
+    return {"citation": citation, "quote_verified": True}

--- a/legal_rinse/report.py
+++ b/legal_rinse/report.py
@@ -1,0 +1,14 @@
+from typing import Iterable, Dict
+
+
+def generate_report(results: Iterable[Dict[str, str]]) -> str:
+    """Generate a plain-text summary of verification results."""
+    lines = []
+    for res in results:
+        if res.get("verified"):
+            link = res.get("link", "")
+            lines.append(f"✅ {res['citation']} - {link}")
+        else:
+            reason = res.get("error", "not found")
+            lines.append(f"❌ {res['citation']} - {reason}")
+    return "\n".join(lines)

--- a/legal_rinse/utils.py
+++ b/legal_rinse/utils.py
@@ -1,0 +1,8 @@
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def log(message: str) -> None:
+    logger.info(message)

--- a/legal_rinse/verifier.py
+++ b/legal_rinse/verifier.py
@@ -1,0 +1,23 @@
+import requests
+from typing import Dict
+
+
+def verify_citation(citation: str) -> Dict[str, str]:
+    """Verify a citation using CourtListener's public API."""
+    endpoint = "https://www.courtlistener.com/api/rest/v3/search/"
+    params = {"q": citation, "type": "opinion"}
+    try:
+        resp = requests.get(endpoint, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:
+        return {"citation": citation, "verified": False, "error": str(exc)}
+
+    results = data.get("results", [])
+    if results:
+        return {
+            "citation": citation,
+            "verified": True,
+            "link": results[0].get("absolute_url"),
+        }
+    return {"citation": citation, "verified": False}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+requests


### PR DESCRIPTION
## Summary
- implement a simple Flask app to run the legal citation checker in a browser
- document usage of command line and web interface
- add requirements.txt for Python dependencies

## Testing
- `python -m py_compile legal_rinse/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685c4d28a06c832bae9a865b56de8ada